### PR TITLE
Bugfix/timeout

### DIFF
--- a/ReaperBoard-Lite/include/main.h
+++ b/ReaperBoard-Lite/include/main.h
@@ -5,6 +5,7 @@
 #include <ESP8266WiFi.h>
 
 #define OFF_SWITCH 3 // 3
+#define TIMEOUT_MINIMUM 15 // Seconds
 
 #include "scanWifi.h"
 #include "menu.h"

--- a/ReaperBoard-Lite/include/sysInfo.h
+++ b/ReaperBoard-Lite/include/sysInfo.h
@@ -18,9 +18,10 @@ private:
     int index = 0;
     int screenTimeoutIndex = SCREEN_TIMEOUT_TIMES_TOTAL;
     int setScreenTimeout = 0;
-    int originalScreenTimeout;
+    int originalScreenTimeout; // Preserves a custom timeout set in SD card
     bool resetDeviceConfirmation = false;
 public:
+    void setOriginalScreenTimeout(int timeout);
     bool scanInputs() override;
     void displayScreen() override;
     void onEnter() override;

--- a/ReaperBoard-Lite/src/main.cpp
+++ b/ReaperBoard-Lite/src/main.cpp
@@ -46,6 +46,8 @@ void setup() {
   
   SDManager::loadSettings(passcode, screenTimeout);
 
+  sysInfoDisplay.setOriginalScreenTimeout(screenTimeout);
+
   loginDisplay.setPasscode(passcode);
 
   initOLED();

--- a/ReaperBoard-Lite/src/main.cpp
+++ b/ReaperBoard-Lite/src/main.cpp
@@ -76,7 +76,7 @@ void runScreen(OLEDDisplay* currentScreen) {
     }
 
     if (currentScreen->timeoutEnabled()) {
-      if ((millis() - lastButtonUpdate) >= ((long unsigned int)screenTimeout * 1000) || checkOffBtn()) {
+      if (((millis() - lastButtonUpdate) >= ((long unsigned int)screenTimeout * 1000) || checkOffBtn()) && (long unsigned int)screenTimeout * 1000 > TIMEOUT_MINIMUM) {
         logout();
         awaitingExit = true;
       }

--- a/ReaperBoard-Lite/src/sysInfo.cpp
+++ b/ReaperBoard-Lite/src/sysInfo.cpp
@@ -103,6 +103,12 @@ void SysInfoDisplay::displayScreen() {
     display.display();
 }
 
+void SysInfoDisplay::setOriginalScreenTimeout(int timeout) {
+    if (timeout >= 15) {
+        originalScreenTimeout = timeout;
+    }
+}
+
 void SysInfoDisplay::onEnter() {
     String passcode;
     SDManager::loadSettings(passcode, setScreenTimeout);


### PR DESCRIPTION
Fixes an issue where setting the login timeout to 0 prevented users from staying logged in.
- Added an absolute minimum timeout value to prevent unintentional logouts.
- Preserved custom user-set timeout from SD card.
- Resolves the underlying reason users may set timeout to 0.

Users can now intentionally set a timeout of 0 to stay logged in indefinitely without being logged out due to the bug.